### PR TITLE
refactor: AuthClient 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,22 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",
+    "@types/sinon": "^10.0.2",
+    "sinon": "^11.1.2",
     "jest": "^27.1.0",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.2"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "\\.test\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json"
+    ]
   }
 }

--- a/src/LoggedClient.ts
+++ b/src/LoggedClient.ts
@@ -1,0 +1,11 @@
+import * as api from './api';
+
+export class LoggedClient {
+  constructor(
+    private token: string,
+  ) { }
+
+  getUser() {
+    return api.getUser(this.token);
+  }
+}

--- a/src/LoggedClient.ts
+++ b/src/LoggedClient.ts
@@ -1,4 +1,4 @@
-import * as api from './api';
+import { DodamAPI } from './api';
 
 export class LoggedClient {
   constructor(
@@ -6,6 +6,6 @@ export class LoggedClient {
   ) { }
 
   getUser() {
-    return api.getUser(this.token);
+    return DodamAPI.getUser(this.token);
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,44 +1,51 @@
 import axios from 'axios';
 import { GetTokenErrorHandler, GetUserErrorHandler, RefreshTokenErrorHandler } from './error';
 import { EndPoints } from './enum/EndPoints';
+import { GetTokenResponse, RefreshTokenResponse, GetUserResponse } from './types';
 
-export const getToken = async (code: string, clientId: string, clientSecret: string) => {
+export const getToken = async (code: string, client_id: string, client_secret: string): Promise<GetTokenResponse> => {
 	try {
 		return (await axios.post(`${EndPoints.DAUTH}`, {
 			code,
-			clientId,
-			clientSecret
+			client_id,
+			client_secret
 		})).data.data;
 	} catch (err) {
 		if (axios.isAxiosError(err)) {
 			GetTokenErrorHandler(err);
 		}
+
+		throw err;
 	}
 }
 
-export const refreshToken = async (refreshToken: string, clientId: string) => {
+export const refreshToken = async (refresh_token: string, client_id: string): Promise<RefreshTokenResponse> => {
 	try {
 		return (await axios.post(`${EndPoints.DAUTH}/refresh`, {
-			refreshToken,
-			clientId
+			refresh_token,
+			client_id
 		})).data.data;
 	} catch (err) {
 		if (axios.isAxiosError(err)) {
 			RefreshTokenErrorHandler(err);
 		}
+
+		throw err;
 	}
 }
 
-export const getUser = async (accessToken: string) => {
+export const getUser = async (access_token: string): Promise<GetUserResponse> => {
 	try {
 		return (await axios.get(`${EndPoints.OPENAPI}`, {
 			headers: {
-				'access-token': accessToken
+				'Authorization': `Bearer ${access_token}`
 			}
 		})).data.data;
 	} catch (err) {
 		if (axios.isAxiosError(err)) {
 			GetUserErrorHandler(err)
 		}
+
+		throw err;
 	}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,44 @@
+import axios from 'axios';
+import { GetTokenErrorHandler, GetUserErrorHandler, RefreshTokenErrorHandler } from './error';
+import { EndPoints } from './enum/EndPoints';
+
+export const getToken = async (code: string, clientId: string, clientSecret: string) => {
+	try {
+		return (await axios.post(`${EndPoints.DAUTH}`, {
+			code,
+			clientId,
+			clientSecret
+		})).data.data;
+	} catch (err) {
+		if (axios.isAxiosError(err)) {
+			GetTokenErrorHandler(err);
+		}
+	}
+}
+
+export const refreshToken = async (refreshToken: string, clientId: string) => {
+	try {
+		return (await axios.post(`${EndPoints.DAUTH}/refresh`, {
+			refreshToken,
+			clientId
+		})).data.data;
+	} catch (err) {
+		if (axios.isAxiosError(err)) {
+			RefreshTokenErrorHandler(err);
+		}
+	}
+}
+
+export const getUser = async (accessToken: string) => {
+	try {
+		return (await axios.get(`${EndPoints.OPENAPI}`, {
+			headers: {
+				'access-token': accessToken
+			}
+		})).data.data;
+	} catch (err) {
+		if (axios.isAxiosError(err)) {
+			GetUserErrorHandler(err)
+		}
+	}
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,49 +3,51 @@ import { GetTokenErrorHandler, GetUserErrorHandler, RefreshTokenErrorHandler } f
 import { EndPoints } from './enum/EndPoints';
 import { GetTokenResponse, RefreshTokenResponse, GetUserResponse } from './types';
 
-export const getToken = async (code: string, client_id: string, client_secret: string): Promise<GetTokenResponse> => {
-	try {
-		return (await axios.post(`${EndPoints.DAUTH}`, {
-			code,
-			client_id,
-			client_secret
-		})).data.data;
-	} catch (err) {
-		if (axios.isAxiosError(err)) {
-			GetTokenErrorHandler(err);
-		}
-
-		throw err;
-	}
-}
-
-export const refreshToken = async (refresh_token: string, client_id: string): Promise<RefreshTokenResponse> => {
-	try {
-		return (await axios.post(`${EndPoints.DAUTH}/refresh`, {
-			refresh_token,
-			client_id
-		})).data.data;
-	} catch (err) {
-		if (axios.isAxiosError(err)) {
-			RefreshTokenErrorHandler(err);
-		}
-
-		throw err;
-	}
-}
-
-export const getUser = async (access_token: string): Promise<GetUserResponse> => {
-	try {
-		return (await axios.get(`${EndPoints.OPENAPI}`, {
-			headers: {
-				'Authorization': `Bearer ${access_token}`
+export class DodamAPI {
+	static async getToken(code: string, client_id: string, client_secret: string): Promise<GetTokenResponse> {
+		try {
+			return (await axios.post(`${EndPoints.DAUTH}`, {
+				code,
+				client_id,
+				client_secret
+			})).data.data;
+		} catch (err) {
+			if (axios.isAxiosError(err)) {
+				GetTokenErrorHandler(err);
 			}
-		})).data.data;
-	} catch (err) {
-		if (axios.isAxiosError(err)) {
-			GetUserErrorHandler(err)
+	
+			throw err;
 		}
+	}
 
-		throw err;
+	static async refreshToken(refresh_token: string, client_id: string): Promise<RefreshTokenResponse> {
+		try {
+			return (await axios.post(`${EndPoints.DAUTH}/refresh`, {
+				refresh_token,
+				client_id
+			})).data.data;
+		} catch (err) {
+			if (axios.isAxiosError(err)) {
+				RefreshTokenErrorHandler(err);
+			}
+	
+			throw err;
+		}
+	}
+
+	static async getUser(access_token: string): Promise<GetUserResponse> {
+		try {
+			return (await axios.get(`${EndPoints.OPENAPI}`, {
+				headers: {
+					'Authorization': `Bearer ${access_token}`
+				}
+			})).data.data;
+		} catch (err) {
+			if (axios.isAxiosError(err)) {
+				GetUserErrorHandler(err)
+			}
+	
+			throw err;
+		}
 	}
 }

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,46 +1,47 @@
 import { AxiosError } from 'axios';
+import { APIError } from '../types';
 
 export const GetTokenErrorHandler = async (err: AxiosError) => {
 	switch (err.response?.data.status) {
 		case 400:
-			throw new Error('검증오류');
+			throw new APIError(400, '검증오류');
 		case 401:
-			throw new Error('잘못된 clientSecret입니다');
+			throw new APIError(401, '잘못된 clientSecret입니다');
 		case 403:
-			throw new Error("변조된 code입니다");
+			throw new APIError(403, "변조된 code입니다");
 		case 410:
-			throw new Error('토큰이 만료 되었습니다');
+			throw new APIError(410, '토큰이 만료 되었습니다');
 		case 500:
-			throw new Error('Open API 서버 오류');
+			throw new APIError(500, 'Open API 서버 오류');
 	}
 }
 
 export const RefreshTokenErrorHandler = async (err: AxiosError) => {
 	switch (err.response?.status) {
 		case 400:
-			throw new Error('잘못된 토큰입니다');
+			throw new APIError(400, '잘못된 토큰입니다');
 		case 401:
-			throw new Error('위조된 토큰입니다');
+			throw new APIError(401, '위조된 토큰입니다');
 		case 404:
-			throw new Error('찾을 수 없는 회원입니다');
+			throw new APIError(404, '찾을 수 없는 회원입니다');
 		case 410:
-			throw new Error('토큰이 만료 되었습니다');
+			throw new APIError(410, '토큰이 만료 되었습니다');
 		case 500:
-			throw new Error('Open API 서버 오류');
+			throw new APIError(500, 'Open API 서버 오류');
 	}
 }
 
 export const GetUserErrorHandler = async (err: AxiosError) => {
 	switch (err.response?.status) {
 		case 400:
-			throw new Error('토큰이 전송되지 않았습니다');
+			throw new APIError(400, '토큰이 전송되지 않았습니다');
 		case 401:
-			throw new Error('위조된 토큰입니다');
+			throw new APIError(401, '위조된 토큰입니다');
 		case 403:
-			throw new Error('유저를 찾을 수 없습니다');
+			throw new APIError(403, '유저를 찾을 수 없습니다');
 		case 410:
-			throw new Error('토큰이 만료 되었습니다');
+			throw new APIError(410, '토큰이 만료 되었습니다');
 		case 500:
-			throw new Error('Open API 서버 오류');
+			throw new APIError(500, 'Open API 서버 오류');
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { ClientConfig } from './types';
 import * as api from './api'
+import { LoggedClient } from './LoggedClient';
 
 export * from './api';
 
@@ -9,19 +10,20 @@ export class AuthClient {
   ) {}
 
   async login(code: string) {
-    return await api.getToken(code, this.config.clientId, this.config.clientSecret);
+    const result =  await api.getToken(code, this.config.clientId, this.config.clientSecret);
+    return new LoggedClient(result.token);
   }
 
-  async getToken(code: string) {
-    return await api.getToken(code, this.config.clientId, this.config.clientSecret);
+  getToken(code: string) {
+    return api.getToken(code, this.config.clientId, this.config.clientSecret);
   }
 
-  async refreshToken(refreshToken: string) {
-    return await api.refreshToken(refreshToken, this.config.clientId);
+  refreshToken(refreshToken: string) {
+    return api.refreshToken(refreshToken, this.config.clientId);
   }
 
-  async getUser(token: string) {
-    return await api.getUser(token);
+  getUser(token: string) {
+    return api.getUser(token);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,45 +1,26 @@
-import axios from 'axios';
-import { GetTokenErrorHandler, GetUserErrorHandler, RefreshTokenErrorHandler } from './error';
-import { EndPoints } from './enum/EndPoints';
+import { ClientConfig } from './types';
+import * as api from './api'
 
-export const getToken = async (code: string, clientId: string, clientSecret: string) => {
-	try {
-		return (await axios.post(`${EndPoints.DAUTH}`, {
-			code,
-			clientId,
-			clientSecret
-		})).data.data;
-	} catch (err) {
-		if (axios.isAxiosError(err)) {
-			GetTokenErrorHandler(err);
-		}
-	}
+export class AuthClient {
+  constructor(
+    private config: ClientConfig
+  ) {}
+
+  async login(code: string) {
+    return await api.getToken(code, this.config.clientId, this.config.clientSecret);
+  }
+
+  async getToken(code: string) {
+    return await api.getToken(code, this.config.clientId, this.config.clientSecret);
+  }
+
+  async refreshToken(refreshToken: string) {
+    return await api.refreshToken(refreshToken, this.config.clientId);
+  }
+
+  async getUser(token: string) {
+    return await api.getUser(token);
+  }
 }
 
-export const refreshToken = async (refreshToken: string, clientId: string) => {
-	try {
-		return (await axios.post(`${EndPoints.DAUTH}/refresh`, {
-			refreshToken,
-			clientId
-		})).data.data;
-	} catch (err) {
-		if (axios.isAxiosError(err)) {
-			RefreshTokenErrorHandler(err);
-		}
-	}
-}
-
-export const getUser = async (accessToken: string) => {
-	try {
-		return (await axios.get(`${EndPoints.OPENAPI}`, {
-			headers: {
-				'access-token': accessToken
-			}
-		})).data.data;
-	} catch (err) {
-		if (axios.isAxiosError(err)) {
-			GetUserErrorHandler(err)
-		}
-
-	}
-}
+export default AuthClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { ClientConfig } from './types';
 import * as api from './api'
 
+export * from './api';
+
 export class AuthClient {
   constructor(
     private config: ClientConfig

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 import { ClientConfig } from './types';
-import * as api from './api'
 import { LoggedClient } from './LoggedClient';
-
-export * from './api';
+import { DodamAPI } from './api';
 
 export class AuthClient {
   constructor(
@@ -10,20 +8,20 @@ export class AuthClient {
   ) {}
 
   async login(code: string) {
-    const result =  await api.getToken(code, this.config.clientId, this.config.clientSecret);
+    const result = await DodamAPI.getToken(code, this.config.clientId, this.config.clientSecret);
     return new LoggedClient(result.token);
   }
 
   getToken(code: string) {
-    return api.getToken(code, this.config.clientId, this.config.clientSecret);
+    return DodamAPI.getToken(code, this.config.clientId, this.config.clientSecret);
   }
 
   refreshToken(refreshToken: string) {
-    return api.refreshToken(refreshToken, this.config.clientId);
+    return DodamAPI.refreshToken(refreshToken, this.config.clientId);
   }
 
   getUser(token: string) {
-    return api.getUser(token);
+    return DodamAPI.getUser(token);
   }
 }
 

--- a/src/tests/AuthClient.test.ts
+++ b/src/tests/AuthClient.test.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { AuthClient } from '..';
-import * as api from '../api';
+import { DodamAPI } from '../api';
 
 describe('AuthClient Config', () => {
   let sandbox: sinon.SinonSandbox;
@@ -14,8 +14,8 @@ describe('AuthClient Config', () => {
   });
 
   test('생성자로 넘긴 Config 값을 활용하여 요청한다.', async () => {
-    const stub = sandbox.stub(api, 'getToken')
-      .resolves(true);
+    const stub = sandbox.stub(DodamAPI, 'getToken')
+      .resolves(true as any);
 
     const client = new AuthClient({
       clientId: 'test-clientId',

--- a/src/tests/AuthClient.test.ts
+++ b/src/tests/AuthClient.test.ts
@@ -1,0 +1,30 @@
+import sinon from 'sinon';
+import { AuthClient } from '..';
+import * as api from '../api';
+
+describe('AuthClient Config', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  test('생성자로 넘긴 Config 값을 활용하여 요청한다.', async () => {
+    const stub = sandbox.stub(api, 'getToken')
+      .resolves(true);
+
+    const client = new AuthClient({
+      clientId: 'test-clientId',
+      clientSecret: 'test-clientSecret',
+    });
+
+    const result = await client.getToken('test-code');
+    expect(result).toBe(true);
+    expect(stub.called).toBe(true);
+    expect(stub.getCall(0).args).toStrictEqual(['test-code', 'test-clientId', 'test-clientSecret']);
+  });
+})

--- a/src/types/APIError.ts
+++ b/src/types/APIError.ts
@@ -1,0 +1,11 @@
+export class APIError extends Error {
+  public code: number;
+
+  constructor(
+    code: number,
+    message: string
+  ) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/types/APIResponse.ts
+++ b/src/types/APIResponse.ts
@@ -1,0 +1,18 @@
+export interface GetTokenResponse {
+  token: string;
+  refresh_token: string;
+}
+
+export interface RefreshTokenResponse {
+  token: string;
+}
+
+export interface GetUserResponse {
+  unique_id: string;
+  grade: number;
+  room: number;
+  number: number;
+  name: string;
+  profile_image: string;
+  access_level: number;
+}

--- a/src/types/ClientConfig.ts
+++ b/src/types/ClientConfig.ts
@@ -1,0 +1,4 @@
+export interface ClientConfig {
+  clientId: string;
+  clientSecret: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './ClientConfig';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,3 @@
 export * from './ClientConfig';
+export * from './APIError';
+export * from './APIResponse';

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,19 +487,33 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
   integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^7.0.2":
+"@sinonjs/fake-timers@^7.0.2", "@sinonjs/fake-timers@^7.0.4", "@sinonjs/fake-timers@^7.1.0", "@sinonjs/fake-timers@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz#2524eae70c4910edccf99b2f4e6efc5894aff7b5"
   integrity sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/samsam@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.0.2.tgz#a0117d823260f282c04bff5f8704bdc2ac6910bb"
+  integrity sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -582,6 +596,13 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
   integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
+
+"@types/sinon@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.2.tgz#f360d2f189c0fd433d14aeb97b9d705d7e4cc0e4"
+  integrity sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==
+  dependencies:
+    "@sinonjs/fake-timers" "^7.1.0"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -1005,6 +1026,11 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -1331,6 +1357,11 @@ is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1847,6 +1878,11 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+just-extend@^4.0.2:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -1871,6 +1907,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash@4.x, lodash@^4.7.0:
   version "4.17.21"
@@ -1954,6 +1995,17 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+nise@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.0.tgz#713ef3ed138252daef20ec035ab62b7a28be645c"
+  integrity sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^7.0.4"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -2061,6 +2113,13 @@ path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 picomatch@^2.0.4, picomatch@^2.2.3:
   version "2.3.0"
@@ -2197,6 +2256,18 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+sinon@^11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-11.1.2.tgz#9e78850c747241d5c59d1614d8f9cbe8840e8674"
+  integrity sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==
+  dependencies:
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" "^7.1.2"
+    "@sinonjs/samsam" "^6.0.2"
+    diff "^5.0.0"
+    nise "^5.1.0"
+    supports-color "^7.2.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -2283,7 +2354,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2386,7 +2457,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8:
+type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
## 작업 배경
우연히 저장소를 살펴보다, 사용하게 될때 반복적으로 아래 인자를 넘겨줘야 하는 부분들이 있습니다.
- clientId
- clientSecret

반복적으로 전달해야하는 인자들을 따로 라이브러리가 처리하면 좋을 것 같아 작업을 해봤습니다.

## 변경사항
- AuthClient 클래스를 추가했습니다.
- AuthClient 클래스에 대한 테스트를 추가했습니다.